### PR TITLE
Update snippet

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ var aliases = {
 Lytics.prototype.initialize = function() {
   var options = alias(this.options, aliases);
   /* eslint-disable */
-  window.jstag = (function(){var t = { _q: [], _c: options, ts: (new Date()).getTime() }; t.send = function(){this._q.push(['ready', 'send', Array.prototype.slice.call(arguments)]); return this; }; return t; })();
+  window.jstag = function() {var t = {_q: [], _c: options, ts: (new Date).getTime() }, e = !1, i = (window, document), n = "/static/io", s = ".min.js", r = Array.prototype.slice, a = "//c.lytics.io", c = "//c.lytics.io", o = "io"; return t.init = function(e) {return c = e.url || c, s = e.min === !1 ? ".js" : s, o = e.tag || o, t._c = e, this }, t.load = function() {var t, r = i.getElementsByTagName("script")[0]; return e = !0, i.getElementById(n) ? this : (t = i.createElement("script"), n = a + "/static/" + o + s, t.id = n, t.src = n, r.parentNode.insertBefore(t, r), this) }, t.bind = function(t) {e || this.load(), this._q.push([t, r.call(arguments, 1)]) }, t.ready = function() {e || this.load(), this._q.push(["ready", r.call(arguments)]) }, t.send = function() {return e || this.load(), this._q.push(["ready", "send", r.call(arguments)]), this }, t }();
   /* eslint-enable */
   this.load(this.ready);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,8 @@ describe('Lytics', function() {
   };
 
   beforeEach(function() {
+    document.cookie += 'seerid=12345.12345';
+
     analytics = new Analytics();
     lytics = new Lytics(options);
     analytics.use(Lytics);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ describe('Lytics', function() {
   var analytics;
   var lytics;
   var options = {
-    cid: '1896',
+    cid: '1477',
     cookie: 'lytics_cookie'
   };
 


### PR DESCRIPTION
Our snippet has changed, which is what was causing loading test failures. This updates the snippet to the newest version and also makes the test parameters a little nicer.

**Two things about this**
1. Tests still fail. This is due to the facade changes (https://github.com/segmentio/facade/pull/83) which have merged, but haven't trickled down through this repo's dependencies yet.
2. I would really like to test this end to end on a site before putting a rubber stamp on it.
