### PR TITLE
fix id mapping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ Lytics.prototype.page = function(page) {
 
 Lytics.prototype.identify = function(identify) {
   window.jstag.send(this.options.stream, identify.traits({
-    id: '_uid'
+    id: 'user_id'
   }));
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -106,7 +106,7 @@ describe('Lytics', function() {
 
       it('should send an id', function() {
         analytics.identify('id');
-        analytics.called(window.jstag.send, 'default', { _uid: 'id' });
+        analytics.called(window.jstag.send, 'default', { user_id: 'id' });
       });
 
       it('should send traits', function() {
@@ -116,7 +116,7 @@ describe('Lytics', function() {
 
       it('should send an id and traits', function() {
         analytics.identify('id', { trait: true });
-        analytics.called(window.jstag.send, 'default', { _uid: 'id', trait: true });
+        analytics.called(window.jstag.send, 'default', { user_id: 'id', trait: true });
       });
     });
 


### PR DESCRIPTION
Following up from conversation [here](https://github.com/segment-integrations/analytics.js-integration-lytics/pull/4#issuecomment-133161230). This _properly_ maps segment userId to lytics' `user_id` and tests appropriately as well. 
