### PR TITLE
Update Subdomain of Tag Endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var Lytics = module.exports = integration('Lytics')
   .option('delay', 2000)
   .option('sessionTimeout', 1800)
   .option('url', '//c.lytics.io')
-  .tag('<script src="https://api.lytics.io/api/tag/{{ cid }}/lio.js">');
+  .tag('<script src="https://c.lytics.io/api/tag/{{ cid }}/lio.js">');
 
 /**
  * Options aliases.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,7 +77,7 @@ describe('Lytics', function() {
       var tag = lytics.templates.library;
 
       analytics.equal(tag.type, 'script');
-      analytics.equal(tag.attrs.src, 'https://api.lytics.io/api/tag/{{ cid }}/lio.js');
+      analytics.equal(tag.attrs.src, 'https://c.lytics.io/api/tag/{{ cid }}/lio.js');
     });
 
     describe('#page', function() {


### PR DESCRIPTION
Improve overall performance by putting core tag behind CDN. 
