### PR TITLE
update core tag to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,8 +16,12 @@ var Lytics = module.exports = integration('Lytics')
   .option('cid', '')
   .option('stream', 'default')
   .option('cookie', 'seerid')
+  .option('min', true)
+  .option('loadid', false)
   .option('delay', 2000)
   .option('sessionTimeout', 1800)
+  .option('blockload', false)
+  .option('qsargs', [])
   .option('url', '//c.lytics.io')
   .tag('<script src="https://c.lytics.io/api/tag/{{ cid }}/lio.js">');
 
@@ -40,7 +44,7 @@ var aliases = {
 Lytics.prototype.initialize = function() {
   var options = alias(this.options, aliases);
   /* eslint-disable */
-  window.jstag = function() {var t = {_q: [], _c: options, ts: (new Date).getTime() }, e = !1, i = (window, document), n = "/static/io", s = ".min.js", r = Array.prototype.slice, a = "//c.lytics.io", c = "//c.lytics.io", o = "io"; return t.init = function(e) {return c = e.url || c, s = e.min === !1 ? ".js" : s, o = e.tag || o, t._c = e, this }, t.load = function() {var t, r = i.getElementsByTagName("script")[0]; return e = !0, i.getElementById(n) ? this : (t = i.createElement("script"), n = a + "/static/" + o + s, t.id = n, t.src = n, r.parentNode.insertBefore(t, r), this) }, t.bind = function(t) {e || this.load(), this._q.push([t, r.call(arguments, 1)]) }, t.ready = function() {e || this.load(), this._q.push(["ready", r.call(arguments)]) }, t.send = function() {return e || this.load(), this._q.push(["ready", "send", r.call(arguments)]), this }, t }();
+  window.jstag=function(){function t(t){return function(){return t.apply(this,arguments),this}}function n(){var n=["ready"].concat(c.call(arguments));return t(function(){n.push(c.call(arguments)),this._q.push(n)})}var i={_q:[],_c:{},ts:(new Date).getTime(),ver:"2.0.0"},c=(window,document,Array.prototype.slice);return i.init=function(t){return i._c=t,t.synchronous||i.loadtagmgr(t),this},i.loadtagmgr=function(t){var n=document.createElement("script");n.type="text/javascript",n.async=!0,n.src=t.url+"/api/tag/"+t.cid+"/lio.js";var i=document.getElementsByTagName("script")[0];i.parentNode.insertBefore(n,i)},i.ready=n(),i.send=n("send"),i.mock=n("mock"),i.identify=n("identify"),i.pageView=n("pageView"),i.bind=t(function(){i._q.push([e,c.call(arguments,1)])}),i.block=t(function(){i._c.blockload=!0}),i.unblock=t(function(){i._c.blockload=!1}),i}(),window.jstag.init(options);
   /* eslint-enable */
   this.load(this.ready);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,9 +35,14 @@ describe('Lytics', function() {
     analytics.compare(Lytics, integration('Lytics')
       .global('jstag')
       .option('cid', '')
+      .option('stream', 'default')
       .option('cookie', 'seerid')
+      .option('min', true)
+      .option('loadid', false)
       .option('delay', 2000)
       .option('sessionTimeout', 1800)
+      .option('blockload', false)
+      .option('qsargs', [])
       .option('url', '//c.lytics.io'));
   });
 


### PR DESCRIPTION
adds new / undocumented options to the init payload and moves to the v2 version of the async tag. 

still to do:
- make sure we are setting the stream correctly for future calls
